### PR TITLE
feat(ui): connect product list screen to local database

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bitlabbr/minhadespensa/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/bitlabbr/minhadespensa/app/App.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.bitlabbr.minhadespensa.uisystem.features.list.ProductsListScreen
+import com.bitlabbr.minhadespensa.uisystem.features.list.ProductListScreen
 import com.bitlabbr.minhadespensa.uisystem.theme.MinhaDespensaTheme
 
 
@@ -40,7 +40,7 @@ fun App() {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                ProductsListScreen()
+                ProductListScreen()
             }
         }
     }

--- a/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductListScreenScreen.kt
+++ b/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductListScreenScreen.kt
@@ -16,61 +16,99 @@
 
 package com.bitlabbr.minhadespensa.uisystem.features.list
 
-import androidx.compose.foundation.layout.Column
+
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Card
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.bitlabbr.minhadespensa.core.domain.model.Product
-import com.bitlabbr.minhadespensa.core.domain.util.AppLogger
-import org.koin.compose.koinInject
+
 import org.koin.compose.viewmodel.koinViewModel
-import org.koin.core.qualifier.named
+import org.koin.core.annotation.KoinExperimentalAPI
 
-
+@OptIn(ExperimentalMaterial3Api::class, KoinExperimentalAPI::class)
 @Composable
-fun ProductsListScreen() {
+fun ProductListScreen() {
     val viewModel = koinViewModel<ProductsListViewModel>()
-    val products by viewModel.uiState.collectAsState()
-    val logger: AppLogger = koinInject(named("ui_logger"))
-
-    val TAG = "ProductsListScreen"
-
-    LaunchedEffect(Unit) {
-        logger.d(TAG, "LaunchedEffect")
-    }
-
-    Scaffold { paddingValues ->
-        LazyColumn(
-            contentPadding = paddingValues,
-            modifier = Modifier.fillMaxSize().padding(16.dp)
-        ) {
-            item {
-                Text("Minha Despensa", modifier = Modifier.padding(bottom = 16.dp))
-            }
-
-            items(products) { product ->
-                ProductItem(product)
+    val state by viewModel.uiState.collectAsState()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Minha Despensa") },
+                colors = TopAppBarDefaults.topAppBarColors()
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { viewModel.addProductTest() }
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Add Item")
             }
         }
-    }
-}
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+        ) {
+            when (val uiState = state) {
+                is ProductsUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
 
-@Composable
-fun ProductItem(product: Product) {
-    Card(modifier = Modifier.padding(vertical = 8.dp)) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = product.name)
-            Text(text = "${product.amount} ${product.measureUnit}")
+                is ProductsUiState.Error -> {
+                    Text(
+                        text = uiState.message,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+
+                is ProductsUiState.Success -> {
+                    if (uiState.produtos.isEmpty()) {
+                        Text(
+                            text = "Nenhum produto. Clique no +",
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    } else {
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            items(uiState.produtos) { product ->
+                                ListItem(
+                                    headlineContent = { Text(product.name) },
+                                    supportingContent = {
+                                        Text("${product.amount} ${product.measureUnit}")
+                                    },
+                                    trailingContent = {
+                                        IconButton(onClick = { viewModel.removerProduct(product.id) }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "Remove Item")
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductListScreenScreen.kt
+++ b/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductListScreenScreen.kt
@@ -92,7 +92,7 @@ fun ProductListScreen() {
                         )
                     } else {
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
-                            items(uiState.produtos) { product ->
+                            items(items = uiState.produtos, key = { it.id }) { product ->
                                 ListItem(
                                     headlineContent = { Text(product.name) },
                                     supportingContent = {

--- a/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductsListViewModel.kt
+++ b/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductsListViewModel.kt
@@ -41,7 +41,7 @@ class ProductsListViewModel(
     val uiState: StateFlow<ProductsUiState> = repository.getAllProducts()
         .map<List<Product>, ProductsUiState> { product ->
             logger.d(TAG, "Lista atualizada do banco. Itens: ${product.size}")
-            val total = product.sumOf { it.amount * 1.0 }
+            val total = product.sumOf { it.amount }
 
             ProductsUiState.Success(
                 produtos = product,

--- a/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductsListViewModel.kt
+++ b/uisystem/src/commonMain/kotlin/com/bitlabbr/minhadespensa/uisystem/features/list/ProductsListViewModel.kt
@@ -18,13 +18,19 @@ package com.bitlabbr.minhadespensa.uisystem.features.list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.bitlabbr.minhadespensa.core.domain.model.MeasureUnit
 import com.bitlabbr.minhadespensa.core.domain.model.Product
 import com.bitlabbr.minhadespensa.core.domain.repository.ProductRepository
 import com.bitlabbr.minhadespensa.core.domain.util.AppLogger
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.random.Random
 
 class ProductsListViewModel(
     private val repository: ProductRepository,
@@ -32,23 +38,51 @@ class ProductsListViewModel(
 ) : ViewModel() {
     private val TAG = "ProductsListViewModel"
     private val _uiState = MutableStateFlow<List<Product>>(emptyList())
-    val uiState: StateFlow<List<Product>> = _uiState.asStateFlow()
+    val uiState: StateFlow<ProductsUiState> = repository.getAllProducts()
+        .map<List<Product>, ProductsUiState> { product ->
+            logger.d(TAG, "Lista atualizada do banco. Itens: ${product.size}")
+            val total = product.sumOf { it.amount * 1.0 }
 
-    init {
-        loadAllProducts()
-    }
+            ProductsUiState.Success(
+                produtos = product,
+                totalEstimado = total
+            )
+        }
+        .catch { e ->
+            logger.e(TAG, "Erro ao carregar produtos: ${e.message}")
+            emit(ProductsUiState.Error("Falha ao carregar dados."))
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = ProductsUiState.Loading
+        )
 
-    private fun loadAllProducts() {
-        logger.d(TAG, "Loading all products...")
+    fun addProductTest() {
         viewModelScope.launch {
-            try {
-                repository.getAllProducts().collect { products ->
-                    logger.d(TAG, "Success! Products loaded: ${products.size}")
-                    _uiState.value = products
-                }
-            } catch (e: Exception) {
-                logger.e(TAG, "Failure to load items", e)
-            }
+            val novoProduto = Product(
+                id = "${Clock.System.now().toEpochMilliseconds()}",
+                name = "Produto ${Random.nextInt(100, 999)}",
+                amount = Random.nextDouble(1.0, 5.0),
+                measureUnit = MeasureUnit.UNITY,
+                expirationDate = null
+            )
+            logger.d(TAG, "Tentando salvar: ${novoProduto.name}")
+            repository.insertProduct(novoProduto)
         }
     }
+
+    fun removerProduct(id: String) {
+        viewModelScope.launch {
+            logger.d(TAG, "Removendo: $id")
+            repository.deleteProductById(id)
+        }
+    }
+}
+
+
+sealed interface ProductsUiState {
+    data object Loading : ProductsUiState
+    data class Success(val produtos: List<Product>, val totalEstimado: Double) : ProductsUiState
+    data class Error(val message: String) : ProductsUiState
 }


### PR DESCRIPTION
- Update `ProductsListViewModel` to consume `ProductRepository` flow.
- Implement `ProductsUiState` (Loading, Success, Error) for reactive UI updates.
- Refactor `ListaProdutosScreen` to observe `StateFlow` from ViewModel.
- Add temporary FAB to insert random test data into Room Database.
- Implement delete functionality directly from the list item.

This change replaces the mock data with real persistence, enabling the "Add" and "Delete" features to reflect immediately on the UI via Kotlin Flows.